### PR TITLE
PR-11 home page 03

### DIFF
--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -22,15 +22,3 @@
 .socialsList li img {
   filter: var(--svg-filter-dark);
 }
-
-/* tablet > 481 */
-@media (min-width: 481px) {
-  .Footer {
-    position: absolute;
-    justify-content: end;
-  }
-
-  .socialsList {
-    margin-right: 40px;
-  }
-}

--- a/src/components/ImageCarousel/ImageCarousel.module.css
+++ b/src/components/ImageCarousel/ImageCarousel.module.css
@@ -17,9 +17,6 @@
 }
 
 .imageContainer img {
-  display: block;
-  width: 100%;
-  height: auto;
   border-radius: var(--border-radius);
 }
 

--- a/src/components/ImageCarousel/ImageCarousel.module.css
+++ b/src/components/ImageCarousel/ImageCarousel.module.css
@@ -40,17 +40,3 @@
 .controls button:last-of-type {
   margin-left: 60px;
 }
-
-/* tablet > 481 */
-@media (min-width: 481px) {
-  .title {
-    height: 156px;
-  }
-
-  .title p {
-    font-size: var(--font-size-large);
-    padding: 24px;
-    margin: 0;
-    color: var(--color-primary);
-  }
-}

--- a/src/components/ImageView/ImageView.module.css
+++ b/src/components/ImageView/ImageView.module.css
@@ -27,9 +27,6 @@
 }
 
 .ImageContainer img {
-  display: block;
-  width: 100%;
-  height: auto;
   border-radius: var(--border-radius);
   box-shadow: var(--box-shadow-image);
 }

--- a/src/components/Navigation/Navigation.module.css
+++ b/src/components/Navigation/Navigation.module.css
@@ -51,11 +51,3 @@
 
   background-color: var(--color-primary);
 }
-
-/* tablet > 481 */
-@media (min-width: 481px) {
-  .Navigation {
-    position: absolute;
-    top: 100px;
-  }
-}

--- a/src/components/Navigation/Navigation.module.css
+++ b/src/components/Navigation/Navigation.module.css
@@ -5,12 +5,6 @@
   padding: 2px 0px;
   border-radius: var(--border-radius);
 
-  position: sticky;
-  left: 0;
-  right: 0;
-  top: 40px;
-  z-index: 100;
-
   display: flex;
   place-content: center;
 

--- a/src/components/PageTitle/PageTitle.module.css
+++ b/src/components/PageTitle/PageTitle.module.css
@@ -1,20 +1,8 @@
 .PageTitle {
-  /* background-color: tan; */
-  font-size: 24px;
-  width: 100%;
-  text-align: center;
+  padding: 1.5rem 0;
 }
 
 .PageTitle h1 {
   color: var(--color-dark);
-}
-
-/* tablet > 481 */
-@media (min-width: 481px) {
-  .PageTitle {
-    font-size: 36px;
-    width: 600px;
-    text-align: left;
-    padding: 5px 0;
-  }
+  font-size: var(--font-size-large);
 }

--- a/src/components/PageTitle/PageTitle.module.css
+++ b/src/components/PageTitle/PageTitle.module.css
@@ -1,0 +1,20 @@
+.PageTitle {
+  /* background-color: tan; */
+  font-size: 24px;
+  width: 100%;
+  text-align: center;
+}
+
+.PageTitle h1 {
+  color: var(--color-dark);
+}
+
+/* tablet > 481 */
+@media (min-width: 481px) {
+  .PageTitle {
+    font-size: 36px;
+    width: 600px;
+    text-align: left;
+    padding: 5px 0;
+  }
+}

--- a/src/components/PageTitle/PageTitle.module.css
+++ b/src/components/PageTitle/PageTitle.module.css
@@ -1,5 +1,6 @@
 .PageTitle {
   padding: 1.5rem 0;
+  text-align: center;
 }
 
 .PageTitle h1 {

--- a/src/components/PageTitle/PageTitle.tsx
+++ b/src/components/PageTitle/PageTitle.tsx
@@ -1,0 +1,11 @@
+type PageTitleProps = { text: string };
+
+import styles from './PageTitle.module.css';
+
+export default function PageTitle({ text }: PageTitleProps) {
+  return (
+    <div className={styles.PageTitle}>
+      <h1>{text}</h1>
+    </div>
+  );
+}

--- a/src/components/ResponsiveWrapper/ResponsiveWrapper.module.css
+++ b/src/components/ResponsiveWrapper/ResponsiveWrapper.module.css
@@ -9,7 +9,7 @@
   justify-content: center;
   align-items: center;
 
-  background-color: var(--color-light);
+  background-color: tan;
 }
 
 /* tablet > 481 */

--- a/src/components/ResponsiveWrapper/ResponsiveWrapper.module.css
+++ b/src/components/ResponsiveWrapper/ResponsiveWrapper.module.css
@@ -16,7 +16,6 @@
 @media (min-width: 481px) {
   .ResponsiveWrapper {
     background-color: rgba(0, 255, 255, 0.75);
-    height: calc(100vh - 150px);
   }
 }
 

--- a/src/components/ResponsiveWrapper/ResponsiveWrapper.module.css
+++ b/src/components/ResponsiveWrapper/ResponsiveWrapper.module.css
@@ -9,6 +9,7 @@
   justify-content: center;
   align-items: center;
 
+  /* TODO: REMOVE FOR DEVELOPMENT ONLY */
   background-color: tan;
 }
 

--- a/src/components/ResponsiveWrapper/ResponsiveWrapper.tsx
+++ b/src/components/ResponsiveWrapper/ResponsiveWrapper.tsx
@@ -2,10 +2,12 @@ import { ReactNode } from 'react';
 
 import styles from './ResponsiveWrapper.module.css';
 
-type PageWrapperProps = {
+type ResponsiveWrapperProps = {
   children: ReactNode;
 };
 
-export default function PageWrapper({ children }: PageWrapperProps) {
+export default function ResponsiveWrapper({
+  children,
+}: ResponsiveWrapperProps) {
   return <div className={styles.ResponsiveWrapper}>{children}</div>;
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,4 +3,5 @@ export { default as Footer } from './Footer/Footer';
 export { default as ImageCarousel } from './ImageCarousel/ImageCarousel';
 export { default as ImageView } from './ImageView/ImageView';
 export { default as Navigation } from './Navigation/Navigation';
+export { default as PageTitle } from './PageTitle/PageTitle';
 export { default as ResponsiveWrapper } from './ResponsiveWrapper/ResponsiveWrapper';

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
   font-weight: var(--font-weight-regular);
   font-size: var(--font-size-small);
 
-  --font-size-smallr: 16px;
+  --font-size-small: 16px;
   --font-size-medium: 24px;
   --font-size-large: 36px;
 

--- a/src/index.css
+++ b/src/index.css
@@ -66,3 +66,9 @@ body {
 p {
   color: var(--color-dark);
 }
+
+img {
+  display: block;
+  width: 100%;
+  height: auto;
+}

--- a/src/pages/AboutPage/AboutPage.tsx
+++ b/src/pages/AboutPage/AboutPage.tsx
@@ -1,9 +1,3 @@
-import { ResponsiveWrapper } from 'src/components';
-
 export default function AboutPage() {
-  return (
-    <ResponsiveWrapper>
-      <h1>About Page</h1>
-    </ResponsiveWrapper>
-  );
+  return <h1>About Page</h1>;
 }

--- a/src/pages/ContactPage/ContactPage.tsx
+++ b/src/pages/ContactPage/ContactPage.tsx
@@ -1,9 +1,3 @@
-import { ResponsiveWrapper } from 'src/components';
-
 export default function ContactPage() {
-  return (
-    <ResponsiveWrapper>
-      <h1>Contact Page</h1>
-    </ResponsiveWrapper>
-  );
+  return <h1>Contact Page</h1>;
 }

--- a/src/pages/ErrorPage/ErrorPage.module.css
+++ b/src/pages/ErrorPage/ErrorPage.module.css
@@ -1,3 +1,0 @@
-.ErrorTitle h1 {
-  color: red;
-}

--- a/src/pages/ErrorPage/ErrorPage.tsx
+++ b/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,19 +1,18 @@
 import { useRouteError } from 'react-router-dom';
 
 import { renderErrorMessage } from 'src/utils/utils';
-import { ResponsiveWrapper } from 'src/components';
 import styles from './ErrorPage.module.css';
 
 export default function ErrorPage() {
   const error = useRouteError();
 
   return (
-    <ResponsiveWrapper>
+    <>
       <div className={styles.ErrorTitle}>
         <h1>Oops!</h1>
       </div>
 
       <p>{renderErrorMessage(error)}</p>
-    </ResponsiveWrapper>
+    </>
   );
 }

--- a/src/pages/ErrorPage/ErrorPage.tsx
+++ b/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,18 +1,16 @@
 import { useRouteError } from 'react-router-dom';
 
 import { renderErrorMessage } from 'src/utils/utils';
-import styles from './ErrorPage.module.css';
+import { PageTitle, ResponsiveWrapper } from 'src/components';
 
 export default function ErrorPage() {
   const error = useRouteError();
 
   return (
-    <>
-      <div className={styles.ErrorTitle}>
-        <h1>Oops!</h1>
-      </div>
+    <ResponsiveWrapper>
+      <PageTitle text='Oops, something went wrong!' />
 
       <p>{renderErrorMessage(error)}</p>
-    </>
+    </ResponsiveWrapper>
   );
 }

--- a/src/pages/ExperiencePage/ExperiencePage.tsx
+++ b/src/pages/ExperiencePage/ExperiencePage.tsx
@@ -1,9 +1,3 @@
-import { ResponsiveWrapper } from 'src/components';
-
 export default function ExperiencePage() {
-  return (
-    <ResponsiveWrapper>
-      <h1>Experience Page</h1>
-    </ResponsiveWrapper>
-  );
+  return <h1>Experience Page</h1>;
 }

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,4 +1,4 @@
-import { ResponsiveWrapper, ImageView, ImageCarousel } from 'src/components';
+import { ImageView, ImageCarousel } from 'src/components';
 
 import useWindowDim from 'src/hooks/useWindowDim';
 import { PageTitle } from 'src/components';
@@ -9,9 +9,9 @@ export default function HomePage() {
   const isScreenMobile = windowDim.width < 540;
 
   return (
-    <ResponsiveWrapper>
+    <>
       <PageTitle text="Hi, I'm Andy" />
       {isScreenMobile ? <ImageView /> : <ImageCarousel />}
-    </ResponsiveWrapper>
+    </>
   );
 }

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,6 +1,7 @@
 import { ResponsiveWrapper, ImageView, ImageCarousel } from 'src/components';
 
 import useWindowDim from 'src/hooks/useWindowDim';
+import { PageTitle } from 'src/components';
 
 export default function HomePage() {
   const { windowDim } = useWindowDim();
@@ -9,7 +10,7 @@ export default function HomePage() {
 
   return (
     <ResponsiveWrapper>
-      <h1>Hi, I'm Andy.</h1>
+      <PageTitle text="Hi, I'm Andy" />
       {isScreenMobile ? <ImageView /> : <ImageCarousel />}
     </ResponsiveWrapper>
   );

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -1,15 +1,35 @@
 import { Outlet } from 'react-router-dom';
 
-import { Navigation, Footer } from '../components';
+import { Footer, Navigation, ResponsiveWrapper } from '../components';
 
 export default function Root() {
   return (
-    <>
-      <Navigation />
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <header
+        style={{
+          backgroundColor: '#fffcfae2',
+          paddingTop: 40,
+          position: 'sticky',
+          top: 0,
+          zIndex: 1000,
+          borderBottomRightRadius: 40,
+          borderBottomLeftRadius: 40,
+        }}
+      >
+        <Navigation />
+      </header>
+
       <main>
-        <Outlet />
+        <ResponsiveWrapper>
+          <Outlet />
+        </ResponsiveWrapper>
       </main>
       <Footer />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
### Summary

This Work removes media queries to be done in future work. Also, implements the use of components where necessary and updates styling.

### Changes

- Adds **PageTitle** component.
- Removes @media query definitions, leaving only responsive wrapper declarations.
- Wraps navigation in a `<header>` element.
- Abstracted **ResposiveWrapper** to top-level rool component.

### Testing Guide

1. `npm run dev`
2. scroll to view `main` content disappear behind the header element.
<img width="446" alt="Screen Shot 2023-11-02 at 2 25 03 PM" src="https://github.com/andrew-oyanguren/typescript-portfolio/assets/69892684/5e49a940-3de9-422c-aec8-f41af20ab595">
<img width="429" alt="Screen Shot 2023-11-02 at 2 26 51 PM" src="https://github.com/andrew-oyanguren/typescript-portfolio/assets/69892684/55354dcf-ec36-48d6-956a-3ff288eefbaf">
