### PR TITLE
PR-21 ContactForm 04 Styles Medium Devices

### DIFF
--- a/src/components/ContactForm/ContactForm.module.css
+++ b/src/components/ContactForm/ContactForm.module.css
@@ -1,18 +1,17 @@
 .ContactForm {
   width: 100%;
-  margin-top: var(--spacing-large);
-}
-
-.ContactForm > * + * {
   margin-top: var(--spacing-medium);
 }
 
-.formControl > input,
+.FormControlContainer > * + * {
+  margin-top: var(--spacing-medium);
+}
+
+.FormControl > input,
 textarea,
 select {
   width: 100%;
-  height: 60px;
-  padding: 16px;
+  padding: 1em;
 
   box-sizing: border-box;
   box-shadow: var(--box-shadow-icon);
@@ -21,27 +20,33 @@ select {
 
   font-size: 18px;
   color: var(--color-dark);
-  background-color: var(--color-light);
+
+  /* TODO: REMOVE FOR DEVELOPMENT ONLY */
+  background-color: pink;
 }
 
-.formControl textarea {
+.FormControl textarea {
   display: block;
   height: 200px;
   resize: none;
 }
 
-.formControl > *:focus {
+.FormControl > *:focus {
   outline: 2px solid var(--color-primary);
 }
 
-.actions img {
+.Actions {
+  margin-top: var(--spacing-medium);
+}
+
+.Actions img {
   width: 36px;
-  height: 36px;
+
   margin-right: 5px;
   filter: var(--svg-filter-light);
 }
 
-.actions button {
+.Actions button {
   width: 100%;
   height: 120px;
 
@@ -54,24 +59,65 @@ select {
   align-items: center;
 
   font-weight: bold;
-  font-size: 24px;
+  font-size: 25px;
   color: var(--color-light);
   background-color: var(--color-primary);
 }
 
-.actions button:disabled {
+.Actions button:disabled {
   box-shadow: none;
   color: var(--color-dark-gray);
   background-color: var(--color-gray);
 }
 
-.error {
+.Error {
   outline: 2px solid var(--color-error);
 }
 
-.errorMessage {
+.ErrorMessage {
   margin: 0;
   padding: 5px 0;
   font-size: 14px;
   color: var(--color-error);
+}
+
+/* MEDIUM_DEVICES: > 768 */
+@media (min-width: 768px) {
+  .ContactForm {
+    display: flex;
+
+    /* TODO: REMOVE FOR DEVELOPMENT ONLY */
+    background-color: burlywood;
+  }
+
+  .FormControlContainer {
+    flex: 2;
+  }
+
+  .FormControl > input,
+  textarea,
+  select {
+    font-size: 25px;
+  }
+
+  .FormControl textarea {
+    height: 280px;
+  }
+
+  .Actions {
+    flex: 1;
+    margin-top: 0;
+    padding-left: var(--spacing-small);
+  }
+
+  .Actions img {
+    width: 55px;
+    margin-right: 10px;
+    filter: var(--svg-filter-light);
+  }
+
+  .Actions button {
+    height: 100%;
+    font-size: 40px;
+  }
 }

--- a/src/components/ContactForm/ContactForm.tsx
+++ b/src/components/ContactForm/ContactForm.tsx
@@ -83,7 +83,7 @@ export default function ContactForm({ onSuccess }: { onSuccess: () => void }) {
       }}
       className={styles.ContactForm}
     >
-      <>
+      <div className={styles.FormControlContainer}>
         {INPUTS_CONFIG.map(
           ({
             inputName,
@@ -94,9 +94,9 @@ export default function ContactForm({ onSuccess }: { onSuccess: () => void }) {
             errorMessage,
           }) => {
             return (
-              <div key={inputName} className={styles.formControl}>
+              <div key={inputName} className={styles.FormControl}>
                 {validation && emailHasError ? (
-                  <p className={styles.errorMessage}>{errorMessage}</p>
+                  <p className={styles.ErrorMessage}>{errorMessage}</p>
                 ) : null}
                 <FormInput
                   inputConfig={{
@@ -105,7 +105,7 @@ export default function ContactForm({ onSuccess }: { onSuccess: () => void }) {
                     props: {
                       ...formatInputProps(inputName, props, validation),
                       className:
-                        validation && emailHasError ? styles.error : '',
+                        validation && emailHasError ? styles.Error : '',
                     },
                     children,
                   }}
@@ -114,9 +114,9 @@ export default function ContactForm({ onSuccess }: { onSuccess: () => void }) {
             );
           }
         )}
-      </>
+      </div>
 
-      <div className={styles.actions}>
+      <div className={styles.Actions}>
         <button type='submit' disabled={!formIsValid}>
           <img src={SendIcon} alt='Send message button' />
           Send

--- a/src/components/PageTitle/PageTitle.module.css
+++ b/src/components/PageTitle/PageTitle.module.css
@@ -5,14 +5,19 @@
 }
 
 /* Inherited styles allow to parent to pass styles. */
-
 .PageTitle h1,
 h2 {
-  font-size: var(--font-size-large);
   color: inherit;
 }
 
 .PageTitle h2 {
-  background-color: var(--color-dark-gray);
   padding: var(--spacing-medium) 0;
+  background-color: var(--color-dark-gray);
+}
+
+/* MEDIUM_DEVICES: > 768 */
+@media (min-width: 768px) {
+  .PageTitle {
+    margin-top: calc(var(--spacing-large) * 5);
+  }
 }

--- a/src/components/ResponsiveWrapper/ResponsiveWrapper.module.css
+++ b/src/components/ResponsiveWrapper/ResponsiveWrapper.module.css
@@ -2,7 +2,7 @@
   width: var(--mobile-width-percent);
   max-width: var(--device-xl-maxWidth);
   margin: 0 auto;
-  min-height: 100vh;
+  min-height: calc(100vh - 150px);
 
   display: flex;
   flex-direction: column;

--- a/src/components/ResponsiveWrapper/ResponsiveWrapper.module.css
+++ b/src/components/ResponsiveWrapper/ResponsiveWrapper.module.css
@@ -13,8 +13,8 @@
   background-color: rgb(223, 207, 158);
 }
 
-/* tablet > 481 */
-@media (min-width: 481px) {
+/* tablet > 768 */
+@media (min-width: 768px) {
   .ResponsiveWrapper {
     /* TODO: REMOVE FOR DEVELOPMENT ONLY */
     background-color: rgba(0, 255, 255, 0.75);

--- a/src/index.css
+++ b/src/index.css
@@ -71,7 +71,8 @@ body {
 }
 
 h1 {
-  margin: var(--spacing-medium);
+  margin: 0;
+  font-size: var(--font-size-large);
 }
 
 p {
@@ -90,4 +91,15 @@ img {
 
 li {
   list-style: none;
+}
+
+/* MEDIUM_DEVICES: > 768 */
+@media (min-width: 768px) {
+  h1 {
+    font-size: calc(var(--font-size-large) * 1.5);
+  }
+
+  p {
+    font-size: calc(var(--font-size-medium) * 1.25);
+  }
 }

--- a/src/pages/ContactPage/ContactPage.module.css
+++ b/src/pages/ContactPage/ContactPage.module.css
@@ -29,6 +29,10 @@
   width: 35px;
 }
 
+.EmailContainer p {
+  padding-left: var(--spacing-small);
+}
+
 /* Success Screen Component */
 .SuccessScreenContainer {
   text-align: center;

--- a/src/pages/ContactPage/ContactPage.module.css
+++ b/src/pages/ContactPage/ContactPage.module.css
@@ -1,42 +1,73 @@
 .TitleContainer {
+  width: 100%;
+
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
+
+  /* TODO: REMOVE FOR DEVELOPMENT ONLY */
+  background-color: rgba(77, 99, 61, 0.75);
 }
 
 .TitleContainer img {
   width: 75px;
-  height: 75px;
+  margin-right: var(--spacing-large);
 }
 
 .EmailContainer {
   width: 100%;
+  margin-top: var(--spacing-medium);
+
   display: flex;
   align-items: flex-end;
 
-  /* background-color: pink; */
+  /* TODO: REMOVE FOR DEVELOPMENT ONLY */
+  background-color: pink;
 }
 
 .EmailContainer img {
   width: 35px;
-  height: 35px;
-  padding: 0 var(--spacing-small);
 }
 
 /* Success Screen Component */
 .SuccessScreenContainer {
   text-align: center;
   height: inherit;
+  max-width: 570px;
 }
 
 .SuccessIconWrapper {
   width: 100%;
+  padding: 60px 0;
+
   display: flex;
   place-content: center;
-  padding: 60px 0;
 }
 
 .SuccessIconWrapper img {
   width: 90px;
-  height: 90px;
+}
+
+/* MEDIUM_DEVICES: > 768 */
+@media (min-width: 768px) {
+  .TitleContainer {
+    /* TODO: REMOVE FOR DEVELOPMENT ONLY */
+    background-color: rgba(106, 255, 0, 0.75);
+
+    justify-content: flex-start;
+  }
+
+  .TitleContainer img {
+    width: 85px;
+    margin-right: 0;
+  }
+
+  .EmailContainer img {
+    width: 45px;
+  }
+
+  /* Success Screen Component */
+  .SuccessIconWrapper {
+    padding: 80px 0;
+  }
 }

--- a/src/pages/ContactPage/ContactPage.tsx
+++ b/src/pages/ContactPage/ContactPage.tsx
@@ -39,14 +39,7 @@ export default function ContactPage() {
   ) : (
     <>
       <div className={styles.TitleContainer}>
-        <PageTitle
-          text="Okay, let's chat!"
-          style={{
-            maxWidth: '65%',
-            marginLeft: 0,
-            marginRight: 0,
-          }}
-        />
+        <PageTitle text="Okay, let's chat!" />
 
         <img src={MessageIcon} alt='Message Icon' />
       </div>


### PR DESCRIPTION
### Summary

This work Added styles for medium devices to the contact form and made some efficient CSS updates as well.

### Changes

- Added breakpoint for medium devices (i.e. 768)
- Adjusted ResponsiveWrapper height to account for footer height
- Standardized CSS names to use Pascal case

### Testing Guide

1. `npm run dev`
2. Navigate to the contact page
3. Open the dev tools -> responsive design
**Initial Page:** 
<img width="631" alt="Screen Shot 2023-11-27 at 6 53 33 PM" src="https://github.com/andrew-oyanguren/typescript-portfolio/assets/69892684/e2eaff00-e050-4205-ad5f-00a78b099280">

**Loading:**
<img width="602" alt="Screen Shot 2023-11-27 at 6 54 24 PM" src="https://github.com/andrew-oyanguren/typescript-portfolio/assets/69892684/eb3c2968-efab-4ab5-8bfe-b80a1b7f37f6">

**Success:**
<img width="606" alt="Screen Shot 2023-11-27 at 6 54 04 PM" src="https://github.com/andrew-oyanguren/typescript-portfolio/assets/69892684/700c1356-3671-438f-a108-a924d731ba25">
