### PR TITLE
PR-22 Home Page 04 (medium size devices)

### DIFF
--- a/src/components/ControlButton/ControlButton.module.css
+++ b/src/components/ControlButton/ControlButton.module.css
@@ -23,9 +23,9 @@
 
 .ControlButton:disabled {
   box-shadow: none;
-  border: none;
+  border-color: var(--color-dark-gray);
   transform: scale(0.98);
-  color: var(--color-gray);
+  background-color: var(--color-gray);
 }
 
 .ControlButton img {

--- a/src/components/ImageCarousel/ImageCarousel.module.css
+++ b/src/components/ImageCarousel/ImageCarousel.module.css
@@ -1,11 +1,19 @@
 .ImageCarousel {
+  width: 100%;
+  margin-top: var(--spacing-medium);
+  padding: var(--spacing-large) 0;
   text-align: center;
-  max-width: 600px;
+
+  background-color: var(--color-gray);
 }
 
-.imageContainer {
-  width: 450px;
-  height: 350px;
+.ImageCarouselContainer {
+  padding-top: var(--spacing-medium);
+}
+
+.ImageWrapper {
+  width: 540px;
+  height: 380px;
 
   margin: 0 auto;
   border-radius: var(--border-radius-common);
@@ -16,23 +24,23 @@
   place-content: center;
 }
 
-.imageContainer img {
+.ImageWrapper img {
   border-radius: var(--border-radius-common);
 }
 
-.title p {
-  padding: 10px;
+.Title p {
   margin: 0;
   color: var(--color-primary);
 }
 
-.controls {
+.Controls {
+  padding: 0;
+  margin-top: var(--spacing-medium);
+
   display: flex;
   justify-content: center;
-
-  padding: 0;
 }
 
-.controls button:last-of-type {
-  margin-left: 60px;
+.Controls button:last-of-type {
+  margin-left: 80px;
 }

--- a/src/components/ImageCarousel/ImageCarousel.tsx
+++ b/src/components/ImageCarousel/ImageCarousel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { IMAGE_CONFIG } from 'src/constants/imageConstants';
+import useWindow from 'src/hooks/useWindowDim';
 
 import { ControlButton } from 'src/components';
 
@@ -10,6 +11,8 @@ export default function ImageCarousel() {
   const [currentImage, setCurrentImage] = useState(
     IMAGE_CONFIG[currentImageIdx]
   );
+
+  const { windowDim } = useWindow();
 
   const isFirstImage = currentImageIdx === 0;
   const isLastImage = currentImageIdx === IMAGE_CONFIG.length - 1;
@@ -32,27 +35,37 @@ export default function ImageCarousel() {
 
   return (
     <div className={styles.ImageCarousel}>
-      <div className={styles.imageContainer}>
-        {<img src={currentImage.asset} alt={currentImage.altText} />}
+      <div className={styles.Title}>
+        {windowDim.width < 1200 ? (
+          <p>{currentImage.title}</p>
+        ) : (
+          <div>
+            {IMAGE_CONFIG.map(({ title }) => (
+              <p key={title}>{title}</p>
+            ))}
+          </div>
+        )}
       </div>
 
-      <div className={styles.title}>
-        <p>{currentImage.title}</p>
-      </div>
+      <div className={styles.ImageCarouselContainer}>
+        <div className={styles.ImageWrapper}>
+          <img src={currentImage.asset} alt={currentImage.altText} />
+        </div>
 
-      <div className={styles.controls}>
-        <ControlButton
-          onClick={onBack}
-          controlType={'Back'}
-          altText='Back button'
-          isDisabled={isFirstImage}
-        />
-        <ControlButton
-          onClick={onNext}
-          controlType={'Next'}
-          altText='Next button'
-          isDisabled={isLastImage}
-        />
+        <div className={styles.Controls}>
+          <ControlButton
+            onClick={onBack}
+            controlType={'Back'}
+            altText='Back button'
+            isDisabled={isFirstImage}
+          />
+          <ControlButton
+            onClick={onNext}
+            controlType={'Next'}
+            altText='Next button'
+            isDisabled={isLastImage}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/ImageView/ImageView.module.css
+++ b/src/components/ImageView/ImageView.module.css
@@ -1,9 +1,16 @@
 .ImageView {
-  text-align: center;
+  width: 100%;
+  background-color: aquamarine;
+  margin-top: var(--spacing-large);
 }
 
 .ImageContainer {
   position: relative;
+  text-align: center;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .ImageContainer:nth-of-type(even) {
@@ -17,7 +24,7 @@
 
 .ImageContainer .title {
   font-weight: var(--font-weight-bold);
-  font-size: 24px;
+
   margin: 0 0 10px 0;
   padding: var(--spacing-small) 0;
 }
@@ -29,6 +36,8 @@
 .ImageContainer img {
   border-radius: var(--border-radius-common);
   box-shadow: var(--box-shadow-image);
+
+  max-width: 500px;
 }
 
 .ImageContainer:first-of-type img {
@@ -37,5 +46,12 @@
 
 .ImageContainer + .ImageContainer {
   margin-top: var(--spacing-large);
-  padding: var(--spacing-large) 0 60px 0;
+  padding: var(--spacing-medium) 0 60px 0;
+}
+
+/* SMALL_MEDIUM_DEVICES: > 640 */
+@media (min-width: 640px) {
+  .ImageView {
+    margin-top: calc(var(--spacing-large) * 1.5);
+  }
 }

--- a/src/components/PageTitle/PageTitle.module.css
+++ b/src/components/PageTitle/PageTitle.module.css
@@ -18,6 +18,6 @@ h2 {
 /* MEDIUM_DEVICES: > 768 */
 @media (min-width: 768px) {
   .PageTitle {
-    margin-top: calc(var(--spacing-large) * 5);
+    margin-top: calc(var(--spacing-large) * 3);
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -6,9 +6,9 @@
   font-weight: var(--font-weight-regular);
   font-size: var(--font-size-small);
 
-  --font-size-small: 16px;
-  --font-size-medium: 20px;
-  --font-size-large: 36px;
+  --font-size-small: 18px;
+  --font-size-medium: 26px;
+  --font-size-large: 42px;
 
   --font-weight-regular: 400;
   --font-weight-bold: 600;
@@ -77,7 +77,7 @@ h1 {
 
 p {
   margin: 0;
-  font-size: var(--font-size-medium);
+  font-size: var(--font-size-small);
   line-height: 1.75;
 
   color: var(--color-dark);
@@ -91,6 +91,13 @@ img {
 
 li {
   list-style: none;
+}
+
+/* SMALL_MEDIUM_DEVICES: > 640 */
+@media (min-width: 640px) {
+  h1 {
+    font-size: calc(var(--font-size-large) * 1.25);
+  }
 }
 
 /* MEDIUM_DEVICES: > 768 */

--- a/src/pages/ContactPage/ContactPage.module.css
+++ b/src/pages/ContactPage/ContactPage.module.css
@@ -67,7 +67,7 @@
   }
 
   .EmailContainer img {
-    width: 45px;
+    width: 55px;
   }
 
   /* Success Screen Component */

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -6,12 +6,12 @@ import { PageTitle } from 'src/components';
 export default function HomePage() {
   const { windowDim } = useWindowDim();
 
-  const isScreenMobile = windowDim.width < 540;
+  const isDeviceSmall = windowDim.width < 768;
 
   return (
     <>
       <PageTitle text="Hi, I'm Andy" />
-      {isScreenMobile ? <ImageView /> : <ImageCarousel />}
+      {isDeviceSmall ? <ImageView /> : <ImageCarousel />}
     </>
   );
 }


### PR DESCRIPTION
### Summary

This work focused on adding support for medium-sized devices on the Home page.

### Changes

- Slightly increased global font sizes.
- Updated CSS for both ImageView and ImageCarousel components
- Various trivial styling changes

### Testing Guide

1. `npm run dev`
2. Open developer tools -> (tablet sizes)
<img width="561" alt="Screen Shot 2023-11-28 at 2 28 13 PM" src="https://github.com/andrew-oyanguren/typescript-portfolio/assets/69892684/f322de53-9bb0-491a-a721-24875cedc886">