### PR TITLE
PR-23 About Page 03 (support medium devices)

### DIFF
--- a/src/components/AboutCard/AboutCard.module.css
+++ b/src/components/AboutCard/AboutCard.module.css
@@ -1,6 +1,7 @@
 .AboutCard {
   width: 100%;
-  max-width: 490px;
+  max-width: 700px;
+  margin-top: var(--spacing-large);
 
   display: flex;
   flex-direction: column;
@@ -12,7 +13,7 @@
   margin-top: calc(var(--spacing-large) * 2);
 }
 
-.header {
+.AboutCardHeader {
   border-top-right-radius: var(--border-radius-common);
   border-top-left-radius: var(--border-radius-common);
 
@@ -23,12 +24,18 @@
   background-color: var(--color-dark);
 }
 
-.header img {
+.AboutCardHeader img {
   width: 65px;
-  height: 65px;
   padding: 24px;
 }
 
-.body {
+.AboutCard .Body {
   flex: 1;
+}
+
+/* MEDIUM_DEVICES: > 768 */
+@media (min-width: 768px) {
+  .AboutCardHeader img {
+    padding: 36px;
+  }
 }

--- a/src/components/AboutCard/AboutCard.tsx
+++ b/src/components/AboutCard/AboutCard.tsx
@@ -14,9 +14,11 @@ export default function AboutCard({
 }: AboutCardTypes) {
   return (
     <div className={styles.AboutCard} style={cardStyles}>
-      <header className={styles.header}>{<img {...iconProps} />}</header>
+      <header className={styles.AboutCardHeader}>
+        {<img {...iconProps} />}
+      </header>
 
-      <div className={styles.body}>{body}</div>
+      <div className={styles.Body}>{body}</div>
     </div>
   );
 }

--- a/src/components/ImageCarousel/ImageCarousel.module.css
+++ b/src/components/ImageCarousel/ImageCarousel.module.css
@@ -12,8 +12,9 @@
 }
 
 .ImageWrapper {
-  width: 540px;
-  height: 380px;
+  width: 465px;
+  height: 310px;
+  overflow: hidden;
 
   margin: 0 auto;
   border-radius: var(--border-radius-common);
@@ -25,7 +26,9 @@
 }
 
 .ImageWrapper img {
-  border-radius: var(--border-radius-common);
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .Title p {

--- a/src/components/ImageView/ImageView.module.css
+++ b/src/components/ImageView/ImageView.module.css
@@ -5,12 +5,26 @@
 }
 
 .ImageContainer {
-  position: relative;
   text-align: center;
+}
 
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+.ImageWrapper {
+  width: 345px;
+  height: 230px;
+  overflow: hidden;
+  margin: 0 auto;
+
+  border-radius: var(--border-radius-common);
+  box-shadow: var(--box-shadow-image);
+
+  position: relative;
+}
+
+.ImageWrapper img {
+  width: 100%;
+  height: 100%;
+
+  object-fit: cover;
 }
 
 .ImageContainer:nth-of-type(even) {
@@ -40,8 +54,9 @@
   max-width: 500px;
 }
 
-.ImageContainer:first-of-type img {
+.ImageContainer:first-of-type .ImageWrapper {
   border-radius: var(--border-radius-circle);
+  height: 345px;
 }
 
 .ImageContainer + .ImageContainer {

--- a/src/components/ImageView/ImageView.tsx
+++ b/src/components/ImageView/ImageView.tsx
@@ -8,7 +8,9 @@ export default function ImageView() {
       {IMAGE_CONFIG.map((obj) => (
         <div key={obj.asset} className={styles.ImageContainer}>
           <p className={styles.title}>{obj.title}</p>
-          <img src={obj.asset} alt={obj.altText} />
+          <div className={styles.ImageWrapper}>
+            <img src={obj.asset} alt={obj.altText} />
+          </div>
         </div>
       ))}
     </div>

--- a/src/pages/AboutPage/AboutPage.tsx
+++ b/src/pages/AboutPage/AboutPage.tsx
@@ -24,12 +24,14 @@ const BackgroundDesign = () => {
 export default function AboutPage() {
   const { windowDim } = useWindowDim();
 
+  const isLargeDevice = windowDim.width > 1200;
+
   return (
     <>
       <BackgroundDesign />
-      <PageTitle text='My Journey' />
+      <PageTitle text='My Journey,' />
 
-      {windowDim.width > 900 ? <Drawer /> : null}
+      {isLargeDevice ? <Drawer /> : null}
       <div style={{ marginTop: 'var(--spacing-large)' }}>
         {ABOUT_CARDS_CONFIG.map(({ cardStyles, iconProps, body }) => (
           <AboutCard


### PR DESCRIPTION
### Summary

This work updates CSS to support medium devices on the About Page.

### Changes

- Updated CSS on the AboutPage including CSS name changes.
- **UNRELATED:** Updated ImageView and ImageCarousel to static sizes, with `<img /> `elements leveraging `object-fit `variable.

### Testing Guide

1. `npm run dev`
2. Navigate to the About page.
3. Open Developer tools -> Tablet Sizes:
<img width="603" alt="Screen Shot 2023-11-29 at 12 32 28 PM" src="https://github.com/andrew-oyanguren/typescript-portfolio/assets/69892684/be0f07ca-6427-4f3f-875f-71d740e21a9e">

