### PR TITLE
PR-33 About Page Large Devices

### DIFF
--- a/src/components/AboutCard/AboutCard.module.css
+++ b/src/components/AboutCard/AboutCard.module.css
@@ -1,12 +1,14 @@
 .AboutCard {
   width: 100%;
-  max-width: 700px;
+
   margin-top: var(--spacing-large);
 
   display: flex;
   flex-direction: column;
 
+  box-shadow: var(--box-shadow-image);
   border-radius: var(--border-radius-medium);
+  outline: 2px solid var(--color-dark);
 }
 
 .AboutCard + .AboutCard {
@@ -45,6 +47,23 @@
 @media (min-width: 768px) {
   .AboutCardHeader img {
     padding: 36px;
+  }
+}
+
+/* LARGE_DEVICES: > 1500 */
+@media (min-width: 1500px) {
+  .AboutCard {
+    flex-direction: row-reverse;
+  }
+
+  .AboutCardHeader {
+    border-top-right-radius: var(--border-radius-medium);
+    border-top-left-radius: 0;
+    border-bottom-right-radius: var(--border-radius-medium);
+  }
+
+  .AboutCardHeader img {
+    padding: 60px calc(var(--spacing-large) * 2);
   }
 }
 

--- a/src/components/Drawer/Drawer.module.css
+++ b/src/components/Drawer/Drawer.module.css
@@ -41,7 +41,7 @@
 .HamburgerContainer {
   display: flex;
   position: absolute;
-  top: 30%;
+  top: 25%;
   right: 100%;
   align-items: center;
 }

--- a/src/components/ResponsiveWrapper/ResponsiveWrapper.module.css
+++ b/src/components/ResponsiveWrapper/ResponsiveWrapper.module.css
@@ -2,23 +2,22 @@
   width: var(--mobile-width-percent);
   max-width: var(--device-xl-maxWidth);
   margin: 0 auto;
-  margin-top: calc(var(--spacing-large) * 2);
+  padding-top: calc(var(--spacing-large) * 2);
 
   display: flex;
   flex-direction: column;
 
   align-items: center;
-  position: relative;
 
   /* TODO: REMOVE FOR DEVELOPMENT ONLY */
-  background-color: rgb(223, 207, 158);
+  /* background-color: rgb(223, 207, 158); */
 }
 
 /* tablet > 768 */
 @media (min-width: 768px) {
   .ResponsiveWrapper {
     min-height: calc(100vh - 320px);
-    background-color: lime;
+    /* background-color: lime; */
   }
 }
 
@@ -26,6 +25,6 @@
 @media (min-width: 1500px) {
   .ResponsiveWrapper {
     min-height: calc(100vh - 90px);
-    background-color: pink;
+    /* background-color: pink; */
   }
 }

--- a/src/constants/aboutCardConstants.tsx
+++ b/src/constants/aboutCardConstants.tsx
@@ -6,8 +6,6 @@ import AboutCardIcon02 from 'src/assets/images/about-card-02.png';
 import AboutCardIcon03 from 'src/assets/images/about-card-03.png';
 import ToolIcon from 'src/assets/svgs/tool.svg';
 
-const commonBoxShadow = 'var(--box-shadow-image)';
-
 const paragraphStyles = {
   padding: 20,
   lineHeight: 2,
@@ -32,8 +30,6 @@ export const ABOUT_CARDS_CONFIG: AboutCardConfigTypes = [
   {
     cardStyles: {
       backgroundColor: 'rgba(255, 138, 0, 0.75)',
-      outline: '2px solid var(--color-dark)',
-      boxShadow: commonBoxShadow,
     },
     body: (
       <p style={paragraphStyles}>
@@ -47,7 +43,6 @@ export const ABOUT_CARDS_CONFIG: AboutCardConfigTypes = [
   },
   {
     cardStyles: {
-      outline: '2px solid var(--color-dark-gray)',
       backgroundColor: 'rgba(189, 202, 206, 0.75)',
     },
     body: (
@@ -63,7 +58,6 @@ export const ABOUT_CARDS_CONFIG: AboutCardConfigTypes = [
   {
     cardStyles: {
       backgroundColor: 'rgba(110, 173, 192, 0.75)',
-      boxShadow: commonBoxShadow,
     },
     body: (
       <p style={paragraphStyles}>
@@ -78,7 +72,6 @@ export const ABOUT_CARDS_CONFIG: AboutCardConfigTypes = [
   {
     cardStyles: {
       backgroundColor: 'var(--color-dark)',
-      boxShadow: commonBoxShadow,
     },
     body: <SkillsCard />,
     iconProps: { src: ToolIcon, alt: ICON_ALT_TEXT.CARD_SKILLS },

--- a/src/constants/aboutCardConstants.tsx
+++ b/src/constants/aboutCardConstants.tsx
@@ -13,10 +13,19 @@ const paragraphStyles = {
   lineHeight: 2,
 };
 
+export const ICON_ALT_TEXT = Object.freeze({
+  CARD_ONE: 'About Card One Icon',
+  CARD_TWO: 'About Card Two Icon',
+  CARD_THREE: 'About Card Three Icon',
+  CARD_SKILLS: 'SKILLS Card Icon',
+});
+
+type IconAltTypes = (typeof ICON_ALT_TEXT)[keyof typeof ICON_ALT_TEXT];
+
 type AboutCardConfigTypes = {
   cardStyles: CSSProperties;
   body: ReactNode;
-  iconProps: { src: string; alt: string };
+  iconProps: { src: string; alt: IconAltTypes };
 }[];
 
 export const ABOUT_CARDS_CONFIG: AboutCardConfigTypes = [
@@ -34,7 +43,7 @@ export const ABOUT_CARDS_CONFIG: AboutCardConfigTypes = [
         is when I discovered JavaScript.
       </p>
     ),
-    iconProps: { src: AboutCardIcon01, alt: 'About Icon One' },
+    iconProps: { src: AboutCardIcon01, alt: ICON_ALT_TEXT.CARD_ONE },
   },
   {
     cardStyles: {
@@ -49,7 +58,7 @@ export const ABOUT_CARDS_CONFIG: AboutCardConfigTypes = [
         200 times, received 4 interviews and was so close...
       </p>
     ),
-    iconProps: { src: AboutCardIcon02, alt: 'About Icon Two' },
+    iconProps: { src: AboutCardIcon02, alt: ICON_ALT_TEXT.CARD_TWO },
   },
   {
     cardStyles: {
@@ -64,7 +73,7 @@ export const ABOUT_CARDS_CONFIG: AboutCardConfigTypes = [
         with a local startup.
       </p>
     ),
-    iconProps: { src: AboutCardIcon03, alt: 'About Icon Three' },
+    iconProps: { src: AboutCardIcon03, alt: ICON_ALT_TEXT.CARD_THREE },
   },
   {
     cardStyles: {
@@ -72,6 +81,6 @@ export const ABOUT_CARDS_CONFIG: AboutCardConfigTypes = [
       boxShadow: commonBoxShadow,
     },
     body: <SkillsCard />,
-    iconProps: { src: ToolIcon, alt: 'About Icon Three' },
+    iconProps: { src: ToolIcon, alt: ICON_ALT_TEXT.CARD_SKILLS },
   },
 ];

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-import { ABOUT_CARDS_CONFIG } from './aboutCardConstants';
+import { ABOUT_CARDS_CONFIG, ICON_ALT_TEXT } from './aboutCardConstants';
 import { BOOKS_LIST_CONFIG } from './BooksListConstants';
 import { IMAGE_CONFIG } from './imageConstants';
 import { PATH_NAMES, NAV_CONFIG } from './routerConstants';
@@ -7,6 +7,7 @@ import { SOCIAL_LINKS } from './socialsConstants';
 export {
   ABOUT_CARDS_CONFIG,
   BOOKS_LIST_CONFIG,
+  ICON_ALT_TEXT,
   IMAGE_CONFIG,
   PATH_NAMES,
   NAV_CONFIG,

--- a/src/pages/AboutPage/AboutPage.module.css
+++ b/src/pages/AboutPage/AboutPage.module.css
@@ -1,3 +1,16 @@
+.AboutCardsContainer {
+  margin-top: var(--spacing-large);
+  background-color: yellow;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.AboutCardsContainer > * {
+  max-width: 768px;
+}
+
 .BackgroundDesign {
   width: 50%;
   z-index: -1;
@@ -20,6 +33,31 @@
     rgba(220, 230, 234, 1) 50%,
     rgba(245, 245, 245, 1) 100%
   );
+}
+
+/* LARGE_DEVICES: > 1500 */
+@media (min-width: 1500px) {
+  .AboutCardsContainer {
+    background-color: pink;
+  }
+
+  .AboutCardsContainer > * {
+    max-width: 1124px;
+  }
+
+  .AboutCardsContainer > div:nth-of-type(2) {
+    flex-direction: row;
+    max-width: 1224px;
+    border-top-left-radius: var(--border-radius-medium);
+    border-bottom-left-radius: var(--border-radius-medium);
+  }
+
+  .AboutCardsContainer > div:nth-of-type(2) > header {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-top-left-radius: var(--border-radius-medium);
+    border-bottom-left-radius: var(--border-radius-medium);
+  }
 }
 
 @keyframes slideLeft {

--- a/src/pages/AboutPage/AboutPage.module.css
+++ b/src/pages/AboutPage/AboutPage.module.css
@@ -23,7 +23,6 @@
 
   animation: slideLeft;
   animation-duration: 0.5s;
-
   animation-timing-function: cubic-bezier(0.47, 0, 0.745, 0.715);
   animation-fill-mode: forwards;
 
@@ -40,11 +39,27 @@
     max-width: 1124px;
   }
 
+  .AboutCardsContainer > div:first-of-type {
+    border-top-right-radius: 50px;
+    border-bottom-left-radius: 50px;
+  }
+
+  .AboutCardsContainer > div:first-of-type > header {
+    border-top-right-radius: 50px;
+  }
+
   .AboutCardsContainer > div:nth-of-type(2) {
+    max-width: 1124px;
     flex-direction: row;
-    max-width: 1224px;
+
     border-top-left-radius: var(--border-radius-medium);
     border-bottom-left-radius: var(--border-radius-medium);
+
+    animation: growLeft;
+    animation-duration: 0.2s;
+    animation-delay: 0.3s;
+    animation-timing-function: linear;
+    animation-fill-mode: forwards;
   }
 
   .AboutCardsContainer > div:nth-of-type(2) > header {
@@ -52,6 +67,24 @@
     border-bottom-right-radius: 0;
     border-top-left-radius: var(--border-radius-medium);
     border-bottom-left-radius: var(--border-radius-medium);
+  }
+
+  .AboutCardsContainer > div:last-of-type {
+    border-top-left-radius: 50px;
+    border-bottom-right-radius: 50px;
+  }
+
+  .AboutCardsContainer > div:last-of-type > header {
+    border-bottom-right-radius: 50px;
+  }
+}
+
+@keyframes growLeft {
+  from {
+    max-width: 1124px;
+  }
+  to {
+    max-width: 1224px;
   }
 }
 

--- a/src/pages/AboutPage/AboutPage.module.css
+++ b/src/pages/AboutPage/AboutPage.module.css
@@ -1,6 +1,5 @@
 .AboutCardsContainer {
   margin-top: var(--spacing-large);
-  background-color: yellow;
 
   display: flex;
   flex-direction: column;
@@ -37,10 +36,6 @@
 
 /* LARGE_DEVICES: > 1500 */
 @media (min-width: 1500px) {
-  .AboutCardsContainer {
-    background-color: pink;
-  }
-
   .AboutCardsContainer > * {
     max-width: 1124px;
   }

--- a/src/pages/AboutPage/AboutPage.tsx
+++ b/src/pages/AboutPage/AboutPage.tsx
@@ -41,7 +41,6 @@ export default function AboutPage() {
 
       {isLargeDevice ? <Drawer /> : null}
       <div className={styles.AboutCardsContainer}>
-        {/* filter */}
         {renderCards(isLargeDevice)}
       </div>
     </>

--- a/src/pages/AboutPage/AboutPage.tsx
+++ b/src/pages/AboutPage/AboutPage.tsx
@@ -1,10 +1,29 @@
 import { Drawer } from 'src/components';
 
-import { ABOUT_CARDS_CONFIG } from 'src/constants';
+import { ABOUT_CARDS_CONFIG, ICON_ALT_TEXT } from 'src/constants';
 import { AboutCard, PageTitle } from 'src/components';
 import { useWindowDim } from 'src/hooks';
 
 import styles from './AboutPage.module.css';
+
+const renderCards = (isLargeDevice: boolean) => {
+  let cards = ABOUT_CARDS_CONFIG;
+
+  if (isLargeDevice) {
+    cards = ABOUT_CARDS_CONFIG.filter(
+      ({ iconProps }) => iconProps.alt !== ICON_ALT_TEXT.CARD_SKILLS
+    );
+  }
+
+  return cards.map(({ cardStyles, iconProps, body }) => (
+    <AboutCard
+      key={iconProps.src}
+      cardStyles={cardStyles}
+      iconProps={iconProps}
+      body={body}
+    />
+  ));
+};
 
 const BackgroundDesign = () => {
   return <div className={styles.BackgroundDesign} />;
@@ -21,15 +40,9 @@ export default function AboutPage() {
       <PageTitle text='My Journey,' />
 
       {isLargeDevice ? <Drawer /> : null}
-      <div style={{ marginTop: 'var(--spacing-large)' }}>
-        {ABOUT_CARDS_CONFIG.map(({ cardStyles, iconProps, body }) => (
-          <AboutCard
-            key={iconProps.src}
-            cardStyles={cardStyles}
-            iconProps={iconProps}
-            body={body}
-          />
-        ))}
+      <div className={styles.AboutCardsContainer}>
+        {/* filter */}
+        {renderCards(isLargeDevice)}
       </div>
     </>
   );


### PR DESCRIPTION
### Summary

This work improves the About page UI on large devices.

### Changes

- Added `ICON_ALT_TEXT `to the aboutCardConstants.
- New rednerCards helper on the About page.
- Added CSS for large devices for:
  - AboutCard
  - AboutPage

### Testing Guide

1. `npm run dev`
2. Navigate to the About page:
<img width="1792" alt="Screen Shot 2023-12-25 at 4 24 27 PM" src="https://github.com/andrew-oyanguren/typescript-portfolio/assets/69892684/1244d08e-506f-4e9b-a743-4f53ae92424e">

<img width="1790" alt="Screen Shot 2023-12-25 at 4 24 37 PM" src="https://github.com/andrew-oyanguren/typescript-portfolio/assets/69892684/56c34a31-2c56-4af4-adde-88d68a686edd">