### PR TITLE
PR-34 Experience  Bar

### DIFF
--- a/src/components/ExperienceBar/ExperienceBar.module.css
+++ b/src/components/ExperienceBar/ExperienceBar.module.css
@@ -1,0 +1,30 @@
+.ExperienceBar {
+  height: 500px;
+
+  position: fixed;
+  top: 50%;
+  right: 10%;
+  transform: translateY(-50%);
+
+  display: grid;
+  place-items: center;
+  grid-template-areas:
+    'top'
+    'middle'
+    'bottom';
+}
+
+.ExperienceBar .Circle {
+  width: 45px;
+  height: 45px;
+  border-radius: var(--border-radius-circle);
+  box-shadow: var(--box-shadow-icon);
+  background-color: var(--color-secondary);
+}
+
+.ExperienceBar .Line {
+  width: 10px;
+  height: 200px;
+  border-radius: 30px;
+  background-color: var(--color-gray);
+}

--- a/src/components/ExperienceBar/ExperienceBar.tsx
+++ b/src/components/ExperienceBar/ExperienceBar.tsx
@@ -1,0 +1,11 @@
+import styles from './ExperienceBar.module.css';
+
+export default function ExperienceBar() {
+  return (
+    <div className={styles.ExperienceBar}>
+      <div style={{ gridArea: 'bottom' }} className={styles.Circle} />
+      <div className={styles.Line} />
+      <div className={styles.Line} />
+    </div>
+  );
+}

--- a/src/components/ExperienceBar/ExperienceBar.tsx
+++ b/src/components/ExperienceBar/ExperienceBar.tsx
@@ -1,9 +1,9 @@
 import styles from './ExperienceBar.module.css';
 
-export default function ExperienceBar() {
+export default function ExperienceBar({ circlePosition = 'top' }) {
   return (
     <div className={styles.ExperienceBar}>
-      <div style={{ gridArea: 'bottom' }} className={styles.Circle} />
+      <div style={{ gridArea: circlePosition }} className={styles.Circle} />
       <div className={styles.Line} />
       <div className={styles.Line} />
     </div>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,7 @@ export { default as Card } from './Card/Card';
 export { default as ContactForm } from './ContactForm/ContactForm';
 export { default as ControlButton } from './ControlButton/ControlButton';
 export { default as Drawer } from './Drawer/Drawer';
+export { default as ExperienceBar } from './ExperienceBar/ExperienceBar';
 export { default as Footer } from './Footer/Footer';
 export { default as ImageCarousel } from './ImageCarousel/ImageCarousel';
 export { default as ImageView } from './ImageView/ImageView';

--- a/src/pages/ExperiencePage/ExperiencePage.tsx
+++ b/src/pages/ExperiencePage/ExperiencePage.tsx
@@ -1,4 +1,4 @@
-import { PageTitle } from 'src/components';
+import { PageTitle, ExperienceBar } from 'src/components';
 
 import { getExperienceUIVariant } from 'src/components/ExperienceUI/helpers';
 import { EXPERIENCE_UI_VARIANTS } from 'src/components/ExperienceUI/constants';
@@ -39,6 +39,7 @@ const PageSection = () => {
           </div>
 
           <div className={styles.Content}>{content}</div>
+          <ExperienceBar />
         </section>
       ))}
     </>

--- a/src/pages/ExperiencePage/ExperiencePage.tsx
+++ b/src/pages/ExperiencePage/ExperiencePage.tsx
@@ -1,3 +1,6 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useInView } from 'react-intersection-observer';
+
 import { PageTitle, ExperienceBar } from 'src/components';
 
 import { getExperienceUIVariant } from 'src/components/ExperienceUI/helpers';
@@ -7,17 +10,20 @@ import styles from './ExperiencePage.module.css';
 
 const EXP_SECTIONS_CONFIG = [
   {
+    id: 'webDev',
     title: 'Web Developer',
     subTitle:
       'While I was studying, and improving my skills, I started offering my services to family and friends designing and building websites',
     content: getExperienceUIVariant(EXPERIENCE_UI_VARIANTS.WEB_DEVELOPER),
   },
   {
+    id: 'jr',
     title: 'Jr. Software Engineer',
     subTitle: "Worked on Reperio's two internal apps: Novo and Pulse.",
     content: getExperienceUIVariant(EXPERIENCE_UI_VARIANTS.JR_ENGINEER),
   },
   {
+    id: 'sr',
     title: 'Software Engineer',
     subTitle: "Held ownership of Reperio's admin site.",
     content: getExperienceUIVariant(EXPERIENCE_UI_VARIANTS.SOFTWARE_ENGINEER),
@@ -25,23 +31,65 @@ const EXP_SECTIONS_CONFIG = [
 ];
 
 const PageSection = () => {
+  const [experienceCirclePosition, setExperienceCirclePosition] =
+    useState('top');
+
+  const { ref: webDevRef } = useInView({ threshold: 0 });
+  const { ref: jrRef, inView: jrInView } = useInView({ threshold: 0 });
+  const { ref: srRef, inView: srInView } = useInView({ threshold: 0 });
+
+  const getRef = (id: string) => {
+    switch (id) {
+      case 'webDev':
+        return webDevRef;
+      case 'jr':
+        return jrRef;
+      case 'sr':
+        return srRef;
+      default:
+        return null;
+    }
+  };
+
+  const getSectionInVIew = useCallback(() => {
+    if (jrInView) {
+      return 'middle';
+    } else if (srInView) {
+      return 'bottom';
+    } else {
+      return 'top';
+    }
+  }, [jrInView, srInView]);
+
+  useEffect(() => {
+    setExperienceCirclePosition(getSectionInVIew());
+  }, [getSectionInVIew]);
+
   return (
     <>
       <PageTitle text='My Experience' />
-      {EXP_SECTIONS_CONFIG.map(({ title, subTitle, content }) => (
-        <section className={styles.ExperiencePageSection} key={title}>
-          <div className={styles.Title}>
-            <PageTitle secondaryTitle={true} text={title} />
-          </div>
 
-          <div className={styles.Subtitle}>
-            <p>{subTitle}</p>
-          </div>
+      {EXP_SECTIONS_CONFIG.map(({ id, title, subTitle, content }) => {
+        return (
+          <section
+            ref={getRef(id)}
+            className={styles.ExperiencePageSection}
+            key={id}
+          >
+            <div className={styles.Title}>
+              <PageTitle secondaryTitle={true} text={title} />
+            </div>
 
-          <div className={styles.Content}>{content}</div>
-          <ExperienceBar />
-        </section>
-      ))}
+            <div className={styles.Subtitle}>
+              <p>{subTitle}</p>
+            </div>
+
+            <div className={styles.Content}>{content}</div>
+          </section>
+        );
+      })}
+
+      <ExperienceBar circlePosition={experienceCirclePosition} />
     </>
   );
 };


### PR DESCRIPTION
### Summary

This work adds an Experience (chronological) Bar to the Experience Page.

### Changes

- New `ExperienceBar` component.
- New `experienceCirclePosition` state on the ExperiencePage, that leverages the `useInView` `react-intersection` state to update the experience bar circle position.

### Testing Guide

1. `npm run dev`
2. Navigate to the Experience Page
3. Scroll to the bottom of the page -> Each new section should update the circle position.
**WebDev section:**
<img width="1790" alt="Screen Shot 2023-12-27 at 2 36 59 PM" src="https://github.com/andrew-oyanguren/typescript-portfolio/assets/69892684/d3eab906-65ae-4096-b519-0d14f81c31e9">
**Jr Section:**
<img width="1789" alt="Screen Shot 2023-12-27 at 2 38 09 PM" src="https://github.com/andrew-oyanguren/typescript-portfolio/assets/69892684/eb2c54e4-4115-4120-8da9-817d110b458d">
**Sr Section:**
<img width="1790" alt="Screen Shot 2023-12-27 at 2 37 57 PM" src="https://github.com/andrew-oyanguren/typescript-portfolio/assets/69892684/b9b37854-56f2-4dae-94c7-af6bf4da737a">
